### PR TITLE
Initialization to avoid mocha explosion

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,6 +2,15 @@ module.exports = function(grunt) {
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
 
+    run: {
+      your_target: {
+        cmd: 'node',
+        args: [
+        'index.js'
+        ]
+      }
+    },
+
     jshint: {
       files: ['Gruntfile.js', 'lib/*.js', 'test/*.js', 'index.js'],
       },
@@ -28,9 +37,10 @@ module.exports = function(grunt) {
     }
   });
 
+  grunt.loadNpmTasks('grunt-run');
   grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-eslint');
   grunt.loadNpmTasks('grunt-mocha-test');
-  grunt.registerTask('test', ['jshint','eslint','mochaTest']);
+  grunt.registerTask('test', ['run','jshint','eslint','mochaTest']);
 };

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "grunt-contrib-watch": "^1.0.0",
     "grunt-eslint": "^19.0.0",
     "grunt-mocha-test": "^0.13.2",
+    "grunt-run": "^0.6.0",
     "jshint": "^2.9.4",
     "mocha": "^3.2.0",
     "mock-stdin": "^0.3.1"


### PR DESCRIPTION

### Description of the Change

Mocha tests were failing due to the preferences(package) not initializing. The error was
```
>> Mocha exploded!
>> TypeError: Cannot read property 'host' of undefined
```

### Benefits

Mocha tests will pass.

### Possible Drawbacks

No possible drawbacks as of now. A new PR coming up, may remove grunt and hence an addition of package(grunt-run) will be obsolete.

### Applicable Issues

Issue #8 