### PR TITLE
Timeout to an evaluation request

### DIFF
--- a/lib/submit.js
+++ b/lib/submit.js
@@ -25,6 +25,10 @@ module.exports = function() {
 	var commit_hash;
 	var spinner = new Spinner('Submitting results. Please wait ...');
 	spinner.setSpinnerString(0);
+	setTimeout(function() {
+		console.error('The evaluation request is taking too long. Exiting now.');
+		process.exit(-2);
+	}, 240000);
 	git.revparse(['--verify','HEAD'], function(err, data) {
 		commit_hash = data;
 		spinner.start();


### PR DESCRIPTION
### Benefits

A pending evaluation request never times out. If for any reason, the evaluation result does not come back from AutolabJS, the client is in deadlock state. We need a timeout mechanism in `lib/submit.js`

### Possible Drawbacks

Not as we know of.

### Applicable Issues

Fixes #25 